### PR TITLE
2.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2.8.3
+
+Added a `buildDebug` build task that preserves source maps.
+
+The `controllerWidth` and `controllerHeight` properties are now binding targets, making it possible to control the size of the windows that are displayed.
+
+When the anchor kind is set to `Event Origin` but the controller is triggered by an event that doesn't contain coordinates, the controller's anchor will be set to the event's target element, if any.
+
+Resolves an issue that caused the `controllerClass` property to not work with `Alert Controller` and `Confirmation Controller`.
+
 # 2.8.2
 
 Resolves an issue that caused mashups displayed by the presentation controllers to have incorrect styling when they had spaces in their name.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
     "name": "BMPresentationController",
-    "version": "2.8.0",
+    "version": "2.8.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "2.8.0",
+            "version": "2.8.3",
             "license": "ISC",
             "dependencies": {
                 "typescriptwebpacksupport": "^2.0.9"
@@ -17,7 +17,7 @@
                 "@types/node": "^12.12.14",
                 "@types/webpack-env": "^1.14.1",
                 "babel-loader": "^8.0.6",
-                "bm-core-ui": "^2.6.10",
+                "bm-core-ui": "^2.8.3",
                 "clean-webpack-plugin": "^3.0.0",
                 "copy-webpack-plugin": "^5.0.5",
                 "css-loader": "^3.2.1",
@@ -1879,9 +1879,9 @@
             "dev": true
         },
         "node_modules/bm-core-ui": {
-            "version": "2.6.10",
-            "resolved": "https://registry.npmjs.org/bm-core-ui/-/bm-core-ui-2.6.10.tgz",
-            "integrity": "sha512-/22uttUE+iTT64hEHsCxObs7XiEizt8kyvk3hIro3G9l7kJGsj8HtKRbeLe/1/fiBZMViHQIJOFrFGHQeXpn3Q==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/bm-core-ui/-/bm-core-ui-2.8.3.tgz",
+            "integrity": "sha512-BPM1bz38k0UZse9FCcB5CL1FpTsdnH8fNXeCt2HIB18k3bBGTvtkVc7dwOQ2g9MU+Oueoc0BRaEYc19P8tP8tw==",
             "dev": true,
             "dependencies": {
                 "kiwi.js": "^1.1.2",
@@ -12248,9 +12248,9 @@
             "dev": true
         },
         "bm-core-ui": {
-            "version": "2.6.10",
-            "resolved": "https://registry.npmjs.org/bm-core-ui/-/bm-core-ui-2.6.10.tgz",
-            "integrity": "sha512-/22uttUE+iTT64hEHsCxObs7XiEizt8kyvk3hIro3G9l7kJGsj8HtKRbeLe/1/fiBZMViHQIJOFrFGHQeXpn3Q==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/bm-core-ui/-/bm-core-ui-2.8.3.tgz",
+            "integrity": "sha512-BPM1bz38k0UZse9FCcB5CL1FpTsdnH8fNXeCt2HIB18k3bBGTvtkVc7dwOQ2g9MU+Oueoc0BRaEYc19P8tP8tw==",
             "dev": true,
             "requires": {
                 "kiwi.js": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "BMPresentationController",
-    "version": "2.8.2",
+    "version": "2.8.3",
     "description": "An extension that contains several presentation controllers.",
     "thingworxServer": "http://localhost:8016",
     "thingworxUser": "Administrator",
@@ -18,6 +18,7 @@
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
         "build": "webpack --mode production",
+        "buildDebug": "webpack --mode development",
         "watch": "webpack --watch --mode development",
         "server": "webpack-dev-server --open",
         "upload": "webpack --mode development --env.upload",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@types/node": "^12.12.14",
         "@types/webpack-env": "^1.14.1",
         "babel-loader": "^8.0.6",
-        "bm-core-ui": "^2.6.10",
+        "bm-core-ui": "^2.8.3",
         "clean-webpack-plugin": "^3.0.0",
         "copy-webpack-plugin": "^5.0.5",
         "css-loader": "^3.2.1",

--- a/src/BMPresentationController.ide.ts
+++ b/src/BMPresentationController.ide.ts
@@ -69,14 +69,14 @@ export class BMControllerBase extends TWComposerWidget {
     /**
      * The controller's width.
      */
-    @description('The controller\'s width.')
-    @property('NUMBER', defaultValue(400)) controllerWidth: number;
+    @description('The controller\'s width. This takes effect the next time this controller\'s window is displayed.')
+    @property('NUMBER', bindingTarget, defaultValue(400)) controllerWidth: number;
 
     /**
      * The controller's height.
      */
-    @description('The controller\'s height.')
-    @property('NUMBER', defaultValue(400)) controllerHeight: number;
+    @description('The controller\'s height. This takes effect the next time this controller\'s window is displayed.')
+    @property('NUMBER', bindingTarget, defaultValue(400)) controllerHeight: number;
 
     /**
      * Controls whether this window can be dismissed using the escape key.

--- a/src/BMPresentationController.runtime.ts
+++ b/src/BMPresentationController.runtime.ts
@@ -644,13 +644,14 @@ let BMControllerSerialVersion = 0;
                     if (window.event instanceof MouseEvent) {
                         const event = window.event as MouseEvent;
                         popover.anchorPoint = BMPointMake(event.clientX, event.clientY);
+                        break;
                     }
                     else if (window.TouchEvent && window.event instanceof window.TouchEvent) {
                         const touch = window.event.changedTouches[0];
                         popover.anchorPoint = BMPointMake(touch.clientX, touch.clientY);
+                        break;
                     }
                 }
-                break;
             case BMPresentationControllerAnchorKind.EventTarget:
                 if (window.event && window.event instanceof UIEvent) {
                     popover.anchorNode = (window.event as any)._BMOriginalTarget || window.event.currentTarget as HTMLElement || window.event.target as HTMLElement;
@@ -801,16 +802,15 @@ let BMControllerSerialVersion = 0;
                 if (window.event) {
                     if (window.event instanceof MouseEvent) {
                         const event = window.event as MouseEvent;
-                        //@ts-ignore
                         popup.anchorRect = BMRectMakeWithOrigin(BMPointMake(event.clientX, event.clientY), {size: BMSizeMake(1, 1)});
+                        break;
                     }
                     else if (window.TouchEvent && window.event instanceof window.TouchEvent) {
                         const touch = window.event.changedTouches[0];
-                        //@ts-ignore
                         popup.anchorRect = BMRectMakeWithOrigin(BMPointMake(touch.clientX, touch.clientY), {size: BMSizeMake(1, 1)});
+                        break;
                     }
                 }
-                break;
             case BMPresentationControllerAnchorKind.EventTarget:
                 if (window.event && window.event instanceof UIEvent) {
                     //@ts-ignore

--- a/src/BMPresentationController.runtime.ts
+++ b/src/BMPresentationController.runtime.ts
@@ -911,6 +911,10 @@ let BMControllerSerialVersion = 0;
 
         this.popup = BMAlertPopup.alertPopupWithTitle(this.title, {text: this.description, actionText: this.confirmationButtonLabel});
         this.popup.delegate = this;
+        
+        if (this.controllerClass) {
+            this.popup.CSSClass = this.controllerClass;
+        }
 
         this.popup.confirm();
     }
@@ -999,6 +1003,10 @@ let BMControllerSerialVersion = 0;
         this.popup = BMConfirmationPopup.confirmationPopupWithTitle(this.title, {text: this.description, positiveActionText: this.confirmationButtonLabel, negativeActionText: this.declineButtonLabel});
         this.popup.showsCancelButton = this.showsCancelButton;
         this.popup.delegate = this;
+
+        if (this.controllerClass) {
+            this.popup.CSSClass = this.controllerClass;
+        }
 
         this.popup.confirm();
     }

--- a/src/BMPresentationController.runtime.ts
+++ b/src/BMPresentationController.runtime.ts
@@ -1,5 +1,5 @@
-////<reference path="../node_modules/bm-core-ui/lib/@types/BMCoreUI.min.d.ts"/>
-///<reference path="../../BMCoreUI/build/ui/BMCoreUI/BMCoreUI.d.ts"/>
+///<reference path="../node_modules/bm-core-ui/lib/@types/BMCoreUI.min.d.ts"/>
+////<reference path="../../BMCoreUI/build/ui/BMCoreUI/BMCoreUI.d.ts"/>
 
 import { TWWidgetDefinition, property, canBind, didBind, TWEvent, event, service } from 'typescriptwebpacksupport/widgetruntimesupport';
 import { BMPresentationControllerAnchorKind } from './shared/constants';


### PR DESCRIPTION
Added a `buildDebug` build task that preserves source maps.

The `controllerWidth` and `controllerHeight` properties are now binding targets, making it possible to control the size of the windows that are displayed.

When the anchor kind is set to `Event Origin` but the controller is triggered by an event that doesn't contain coordinates, the controller's anchor will be set to the event's target element, if any. Fixes #21 

Resolves an issue that caused the `controllerClass` property to not work with `Alert Controller` and `Confirmation Controller`.