### PR TITLE
Fix mashup loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.8.4
+
+Resolves an issue that caused the `Loaded` event to not fire on mashups loaded via presentation controllers.
+
 # 2.8.3
 
 Added a `buildDebug` build task that preserves source maps.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "BMPresentationController",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "description": "An extension that contains several presentation controllers.",
     "thingworxServer": "http://localhost:8016",
     "thingworxUser": "Administrator",


### PR DESCRIPTION
Resolves an issue that prevented the `Loaded` event from triggering on mashups on Thingworx 9.2.8, 9.3.3 or later.